### PR TITLE
Allow styles legends info to be provided by XML configuration or WMS capabilities document

### DIFF
--- a/documentation/en/user/source/configuration/layers/index.rst
+++ b/documentation/en/user/source/configuration/layers/index.rst
@@ -13,6 +13,7 @@ This section describes how to manually configure layers in GeoWebCache and provi
    projections
    palettes
    parameterfilters
+   styleslegends
    requestfilters
    arcgistilingschemes
    staticcaps

--- a/documentation/en/user/source/configuration/layers/styleslegends.rst
+++ b/documentation/en/user/source/configuration/layers/styleslegends.rst
@@ -1,0 +1,100 @@
+.. _configuration.layers.parameterfilters:
+
+Styles Legends
+==============
+
+In WMTS and WMS services capabilities documents, styles can be associated with a ``<LegendURL>`` element that allows clients to retrieve an image representing the style legend. In the following example we can see the ``<LegendURL>`` element for ``rain`` style: 
+
+.. code-block:: xml
+
+  <Style>
+    <Name>rain</Name>
+    <LegendURL width="128" height="123">
+      <Format>image/png</Format>
+      <OnlineResource xlink:type="simple" xlink:href="http://localhost:8080/geoserver/ows?service=WMS&request=GetLegendGraphic&format=image/png&width=128&height=123&layer=topp:states&style=rain"/>
+    </LegendURL>
+  </Style>
+
+When using GeoWebCache integration with GeoServer, styles legends are automatically configured for GeoServer layers. Layers configured using a WMS capabilities document will also have their styles legends automatically configured.
+
+When configuring a layer using the REST interface or through ``geowebcache.xml`` configuration file the user needs to configure the styles legends, otherwise no ``<LegendURL>`` elements will be included in WMS and WMTS services capabilities documents.
+
+Both REST interface and ``geowebcache.xml`` configuration file use the same XML structure. A legend configuration is associated with a certain style in the context of a certain layer, follows a configuration example:
+
+.. code-block:: xml
+
+   <wmsLayer>
+      <name>topp:states</name>
+      <parameterFilters>
+        <stringParameterFilter>
+          <key>STYLES</key>
+          <defaultValue>population</defaultValue>
+          <values>
+            <string>population</string>
+            <string>polygon</string>
+            <string>pophatch</string>
+          </values>
+        </stringParameterFilter>
+      </parameterFilters>
+      <wmsUrl>
+        <string>http://localhost:8080/geoserver/topp/wms</string>
+      </wmsUrl>
+      <legends defaultWidth="20" defaultHeight="20" defaultFormat="image/png">
+        <legend style="population"/>
+        <legend style="pophatch">
+          <format>image/jpeg</format>
+          <url>http://localhost:8020/geowebcache/wms</url>
+        </legend>
+        <legend style="polygon">
+          <width>50</width>
+          <height>100</height>
+          <format>image/gif</format>
+          <completeUrl>http://localhost/polygon.gif</completeUrl>
+        </legend>
+      </legends>
+    </wmsLayer>
+
+A valid legend configuration requires the following properties:
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 1
+
+   * - Property
+     - Description
+   * - style
+     - the style to which this legend belongs 
+   * - width
+     - the width of the legend image 
+   * - height
+     - the height of the legend image
+   * - format
+     - the image format of the legend image
+   * - url
+     - the url that can be used to retrieve the legend image
+
+This properties can be provided in several ways using ``<legends>`` and ``<legend>`` elements. Default values for properties ``width``, ``height`` and ``format`` can be configured using respectively attributes ``defaultWidth``, ``defaultHeight`` and ``defaultFormat`` of ``<legends>`` element. The default values can be overridden using elements ``width``, ``height`` and ``format`` inside ``<legend>`` elements.
+
+The ``style`` property value needs to be provided using ``style`` attribute of ``<legend>`` elements. The ``url`` property is a little more complex, if nothing is say the WMS layer base URL will be used to build a WMS ``GetLegendGraphic`` request. Element ``<url>`` can be used to provide another base URL, and this one will be used instead of the layer base URL. Element ``<completeUrl>`` can be used to provide an URL that should be used as is to retrieve the legend image.
+
+Looking at the example above, the legend configured for ``population`` style will produce the following legend url:
+
+.. code-block:: xml
+
+  <LegendURL width="20" height="20" format="image/png" 
+    xlink:href="http://localhost:8080/geoserver/topp/wms?service=WMS&amp;request=GetLegendGraphic&amp;format=image/png&amp;width=20&amp;height=20&amp;layer=topp%3Astates&amp;style=population"/>
+
+Note that the layer base URL was used as the base URL for the legend URL. In the example above a different base URL is provided for the legend associated with style ``pophatch`` using the ``<url>`` element. The produced legend URL will look like this:
+
+.. code-block:: xml
+
+  <LegendURL width="20" height="20" format="image/png" 
+    xlink:href="http://localhost:8020/geowebcache/wms?service=WMS&amp;request=GetLegendGraphic&amp;format=image/jpeg&amp;width=20&amp;height=20&amp;layer=topp%3Astates&amp;style=pophatch"/>
+
+In some situations it may be useful to provide an already complete URL to the legend image (custom vendors parameters, a static image or different protocol). In the example above the legend URL for style ``polygon`` will use an already complete URL and will look like this:
+
+.. code-block:: xml
+
+  <LegendURL width="50" height="100" format="image/gif" xlink:href="http://localhost/polygon.gif"/>
+
+When building a legend URL for a certain style if is not possible to retrieve the properties listed above an exception will be throw.

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
@@ -49,12 +49,13 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.GeoWebCacheExtensions;
 import org.geowebcache.config.ContextualConfigurationProvider.Context;
+import org.geowebcache.config.legends.LegendsRawInfo;
+import org.geowebcache.config.legends.LegendsRawInfoConverter;
 import org.geowebcache.config.meta.ServiceInformation;
 import org.geowebcache.filter.parameters.CaseNormalizer;
 import org.geowebcache.filter.parameters.FloatParameterFilter;
@@ -443,6 +444,10 @@ public class XMLConfiguration implements Configuration, InitializingBean {
 
         // xs.alias("layers", List.class);
         xs.alias("wmsLayer", WMSLayer.class);
+
+        // configuration for legends info
+        xs.registerConverter(new LegendsRawInfoConverter());
+        xs.alias("legends", LegendsRawInfo.class);
 
         xs.alias("blobStores", new ArrayList<BlobStoreConfig>().getClass());
         xs.alias("FileBlobStore", FileBlobStoreConfig.class);

--- a/geowebcache/core/src/main/java/org/geowebcache/config/legends/LegendInfo.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/legends/LegendInfo.java
@@ -1,0 +1,58 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Nuno Oliveira, GeoSolutions S.A.S., Copyright 2016
+ */
+package org.geowebcache.config.legends;
+
+/**
+ * Simple container for the information related with a style legends. Builder
+ * {@link LegendInfoBuilder} should be used to create instances of this class.
+ */
+public class LegendInfo {
+
+    private final String styleName;
+    private final int width;
+    private final int height;
+    private final String format;
+    private final String legendUrl;
+
+    LegendInfo(String styleName, int width, int height, String format, String legendUrl) {
+        this.styleName = styleName;
+        this.width = width;
+        this.height = height;
+        this.format = format;
+        this.legendUrl = legendUrl;
+    }
+
+    public String getStyleName() {
+        return styleName;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public String getFormat() {
+        return format;
+    }
+
+    public String getLegendUrl() {
+        return legendUrl;
+    }
+}

--- a/geowebcache/core/src/main/java/org/geowebcache/config/legends/LegendInfoBuilder.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/legends/LegendInfoBuilder.java
@@ -1,0 +1,144 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Nuno Oliveira, GeoSolutions S.A.S., Copyright 2016
+ */
+package org.geowebcache.config.legends;
+
+import com.google.common.base.Preconditions;
+import org.geowebcache.util.ServletUtils;
+
+/**
+ * Builder for {@link LegendInfo} instances.
+ */
+public class LegendInfoBuilder {
+
+    private String layerName;
+    private String layerUrl;
+
+    private Integer defaultWidth;
+    private Integer defaultHeight;
+    private String defaultFormat;
+
+    private String styleName;
+    private Integer width;
+    private Integer height;
+    private String format;
+    private String url;
+    private String completeUrl;
+
+    public LegendInfoBuilder withLayerName(String layerName) {
+        this.layerName = layerName;
+        return this;
+    }
+
+    public LegendInfoBuilder withLayerUrl(String layerUrl) {
+        this.layerUrl = layerUrl;
+        return this;
+    }
+
+    public LegendInfoBuilder withDefaultWidth(Integer defaultWidth) {
+        this.defaultWidth = defaultWidth;
+        return this;
+    }
+
+    public LegendInfoBuilder withDefaultHeight(Integer defaultHeight) {
+        this.defaultHeight = defaultHeight;
+        return this;
+    }
+
+    public LegendInfoBuilder withDefaultFormat(String defaultFormat) {
+        this.defaultFormat = defaultFormat;
+        return this;
+    }
+
+    public LegendInfoBuilder withStyleName(String styleName) {
+        this.styleName = styleName;
+        return this;
+    }
+
+    public LegendInfoBuilder withWidth(Integer width) {
+        this.width = width;
+        return this;
+    }
+
+    public LegendInfoBuilder withHeight(Integer height) {
+        this.height = height;
+        return this;
+    }
+
+    public LegendInfoBuilder withFormat(String format) {
+        this.format = format;
+        return this;
+    }
+
+    public LegendInfoBuilder withUrl(String url) {
+        this.url = url;
+        return this;
+    }
+
+    public LegendInfoBuilder withCompleteUrl(String completeUrl) {
+        this.completeUrl = completeUrl;
+        return this;
+    }
+
+    public LegendInfo build() {
+        // let's see if we need to really on the default values for width, height and format
+        Integer finalWidth = width == null ? defaultWidth : width;
+        Integer finalHeight = height == null ? defaultHeight : height;
+        String finalFormat = format == null ? defaultFormat : format;
+        // checking id we have correct values for width, height and format
+        Preconditions.checkNotNull(finalWidth, "A legend width is mandatory.");
+        Preconditions.checkNotNull(finalHeight, "A legend height is mandatory.");
+        Preconditions.checkNotNull(finalHeight, "A legend image format is mandatory.");
+        // default styles can have a NULL name
+        String finalStyleName = styleName == null ? "" : styleName;
+        // building the legend url
+        String finalUrl = buildFinalUrl(finalStyleName, finalWidth, finalHeight, finalFormat);
+        return new LegendInfo(finalStyleName, finalWidth, finalHeight, finalFormat, finalUrl);
+    }
+
+    /**
+     * Helper method that builds the legend get url using the available info.
+     */
+    private String buildFinalUrl(String finalStyleName, Integer finalWidth, Integer finalHeight, String finalFormat) {
+        if (completeUrl != null) {
+            // we have a complete url so let's just return it
+            return completeUrl;
+        }
+        String finalUrl = url == null ? layerUrl : url;
+        // the legend url and layer name are mandatory
+        Preconditions.checkNotNull(finalUrl, "A legend url is mandatory.");
+        Preconditions.checkNotNull(layerName, "A layer name is mandatory.");
+        return finalUrl + addQuoteMark(finalUrl) +
+                "service=WMS&request=GetLegendGraphic" +
+                "&format=" + finalFormat +
+                "&width=" + finalWidth +
+                "&height=" + finalHeight +
+                "&layer=" + ServletUtils.URLEncode(layerName) +
+                "&style=" + ServletUtils.URLEncode(finalStyleName);
+    }
+
+    /**
+     * Helper method check's if a quote separating the base url from the query parameters
+     * needs to be added to the url or not.
+     */
+    private String addQuoteMark(String finalUrl) {
+        if (finalUrl.indexOf("?") == finalUrl.length() - 1) {
+            // we are good no quote needed
+            return "";
+        }
+        return "?";
+    }
+}

--- a/geowebcache/core/src/main/java/org/geowebcache/config/legends/LegendRawInfo.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/legends/LegendRawInfo.java
@@ -1,0 +1,122 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Nuno Oliveira, GeoSolutions S.A.S., Copyright 2016
+ */
+package org.geowebcache.config.legends;
+
+/**
+ * Contains the raw information about a style legend as it may appear
+ * in the XML configuration for example.
+ */
+public class LegendRawInfo {
+
+    private String style;
+    private Integer width;
+    private Integer height;
+    private String format;
+    private String url;
+    private String completeUrl;
+
+    public String getStyle() {
+        return style;
+    }
+
+    public void setStyle(String style) {
+        this.style = style;
+    }
+
+    public Integer getWidth() {
+        return width;
+    }
+
+    public void setWidth(Integer width) {
+        this.width = width;
+    }
+
+    public Integer getHeight() {
+        return height;
+    }
+
+    public void setHeight(Integer height) {
+        this.height = height;
+    }
+
+    public String getFormat() {
+        return format;
+    }
+
+    public void setFormat(String format) {
+        this.format = format;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getCompleteUrl() {
+        return completeUrl;
+    }
+
+    public void setCompleteUrl(String completeUrl) {
+        this.completeUrl = completeUrl;
+    }
+
+    /**
+     * Build the concrete legend information using the provided layer information and defaults values.
+     */
+    public LegendInfo getLegendInfo(String layerName, String layerUrl, Integer defaultWidth, Integer defaultHeight, String defaultFormat) {
+        return new LegendInfoBuilder()
+                .withLayerName(layerName)
+                .withLayerUrl(layerUrl)
+                .withDefaultWidth(defaultWidth)
+                .withDefaultHeight(defaultHeight)
+                .withDefaultFormat(defaultFormat)
+                .withStyleName(style)
+                .withWidth(width)
+                .withHeight(height)
+                .withFormat(format)
+                .withUrl(url)
+                .withCompleteUrl(completeUrl)
+                .build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LegendRawInfo that = (LegendRawInfo) o;
+        if (style != null ? !style.equals(that.style) : that.style != null) return false;
+        if (width != null ? !width.equals(that.width) : that.width != null) return false;
+        if (height != null ? !height.equals(that.height) : that.height != null) return false;
+        if (format != null ? !format.equals(that.format) : that.format != null) return false;
+        if (url != null ? !url.equals(that.url) : that.url != null) return false;
+        return completeUrl != null ? completeUrl.equals(that.completeUrl) : that.completeUrl == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = style != null ? style.hashCode() : 0;
+        result = 31 * result + (width != null ? width.hashCode() : 0);
+        result = 31 * result + (height != null ? height.hashCode() : 0);
+        result = 31 * result + (format != null ? format.hashCode() : 0);
+        result = 31 * result + (url != null ? url.hashCode() : 0);
+        result = 31 * result + (completeUrl != null ? completeUrl.hashCode() : 0);
+        return result;
+    }
+}

--- a/geowebcache/core/src/main/java/org/geowebcache/config/legends/LegendsRawInfo.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/legends/LegendsRawInfo.java
@@ -1,0 +1,79 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Nuno Oliveira, GeoSolutions S.A.S., Copyright 2016
+ */
+package org.geowebcache.config.legends;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Container for raw legends and the related default values.
+ */
+public class LegendsRawInfo {
+
+    private Integer defaultWidth;
+    private Integer defaultHeight;
+    private String defaultFormat;
+
+    private List<LegendRawInfo> legendsRawInfo = new ArrayList<>();
+
+    public Integer getDefaultWidth() {
+        return defaultWidth;
+    }
+
+    public void setDefaultWidth(Integer defaultWidth) {
+        this.defaultWidth = defaultWidth;
+    }
+
+    public Integer getDefaultHeight() {
+        return defaultHeight;
+    }
+
+    public void setDefaultHeight(Integer defaultHeight) {
+        this.defaultHeight = defaultHeight;
+    }
+
+    public String getDefaultFormat() {
+        return defaultFormat;
+    }
+
+    public void setDefaultFormat(String defaultFormat) {
+        this.defaultFormat = defaultFormat;
+    }
+
+    public void addLegendRawInfo(LegendRawInfo legendRawInfo) {
+        legendsRawInfo.add(legendRawInfo);
+    }
+
+    public List<LegendRawInfo> getLegendsRawInfo() {
+        return legendsRawInfo;
+    }
+
+    /**
+     * Builds the concrete legends info for each raw legend info using the provided layer information.
+     * The returned map index the legend info per layer.
+     */
+    public Map<String, LegendInfo> getLegendsInfo(String layerName, String layerUrl) {
+        Map<String, LegendInfo> legendsInfo = new HashMap<>();
+        for (LegendRawInfo legendRawInfo : legendsRawInfo) {
+            legendsInfo.put(legendRawInfo.getStyle(),
+                    legendRawInfo.getLegendInfo(layerName, layerUrl, defaultWidth, defaultHeight, defaultFormat));
+        }
+        return legendsInfo;
+    }
+}

--- a/geowebcache/core/src/main/java/org/geowebcache/config/legends/LegendsRawInfoConverter.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/legends/LegendsRawInfoConverter.java
@@ -1,0 +1,119 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Nuno Oliveira, GeoSolutions S.A.S., Copyright 2016
+ */
+package org.geowebcache.config.legends;
+
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+
+/**
+ * XML converter for {@link LegendsRawInfo}.
+ */
+public class LegendsRawInfoConverter implements Converter {
+
+    @Override
+    public void marshal(Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
+        LegendsRawInfo legendsRawInfo = (LegendsRawInfo) source;
+        // encode default values
+        writer.addAttribute("defaultWidth", String.valueOf(legendsRawInfo.getDefaultWidth()));
+        writer.addAttribute("defaultHeight", String.valueOf(legendsRawInfo.getDefaultHeight()));
+        writer.addAttribute("defaultFormat", String.valueOf(legendsRawInfo.getDefaultFormat()));
+        // encode legends information
+        for (LegendRawInfo legendRawInfo : legendsRawInfo.getLegendsRawInfo()) {
+            writer.startNode("legend");
+            writer.addAttribute("style", legendRawInfo.getStyle());
+            encodeAttribute(writer, "width", legendRawInfo.getWidth());
+            encodeAttribute(writer, "height", legendRawInfo.getHeight());
+            encodeAttribute(writer, "format", legendRawInfo.getFormat());
+            encodeAttribute(writer, "url", legendRawInfo.getUrl());
+            encodeAttribute(writer, "completeUrl", legendRawInfo.getCompleteUrl());
+            writer.endNode();
+        }
+    }
+
+    private void encodeAttribute(HierarchicalStreamWriter writer, String name, Object value) {
+        if (value == null) {
+            return;
+        }
+        writer.startNode(name);
+        writer.setValue(value.toString());
+        writer.endNode();
+    }
+
+    @Override
+    public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+        LegendsRawInfo legendsRawInfo = new LegendsRawInfo();
+        // setting the defaults based on legends element attributes
+        legendsRawInfo.setDefaultWidth(toInteger(reader.getAttribute("defaultWidth")));
+        legendsRawInfo.setDefaultHeight(toInteger(reader.getAttribute("defaultHeight")));
+        legendsRawInfo.setDefaultFormat(reader.getAttribute("defaultFormat"));
+        // parsing all legends information
+        while(reader.hasMoreChildren()) {
+            reader.moveDown();
+            legendsRawInfo.addLegendRawInfo(parseLegendRawInfo(reader));
+            reader.moveUp();
+        }
+        return legendsRawInfo;
+    }
+
+    /**
+     * Helper method that converts a non NULL string value to an integer.
+     */
+    private Integer toInteger(String rawValue) {
+        if (rawValue == null) {
+            return null;
+        }
+        return Integer.valueOf(rawValue);
+    }
+
+    /**
+     * Helper method that retrieves from the reader a legend raw information.
+     */
+    private LegendRawInfo parseLegendRawInfo(HierarchicalStreamReader reader) {
+        LegendRawInfo legendRawInfo = new LegendRawInfo();
+        legendRawInfo.setStyle(reader.getAttribute("style"));
+        while(reader.hasMoreChildren()) {
+            reader.moveDown();
+            switch(reader.getNodeName()) {
+                case "width":
+                    legendRawInfo.setWidth(toInteger(reader.getValue()));
+                    break;
+                case "height":
+                    legendRawInfo.setHeight(toInteger(reader.getValue()));
+                    break;
+                case "format":
+                    legendRawInfo.setFormat(reader.getValue());
+                    break;
+                case "url":
+                    legendRawInfo.setUrl(reader.getValue());
+                    break;
+                case "completeUrl":
+                    legendRawInfo.setCompleteUrl(reader.getValue());
+                    break;
+            }
+            reader.moveUp();
+        }
+        return legendRawInfo;
+    }
+
+    @Override
+    public boolean canConvert(Class type) {
+        return type.equals(LegendsRawInfo.class);
+    }
+}

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayer.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/TileLayer.java
@@ -32,6 +32,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geowebcache.GeoWebCacheException;
+import org.geowebcache.config.legends.LegendInfo;
 import org.geowebcache.conveyor.ConveyorTile;
 import org.geowebcache.filter.parameters.ParameterFilter;
 import org.geowebcache.filter.request.RequestFilter;
@@ -245,26 +246,7 @@ public abstract class TileLayer {
      * Returns legend info indexed by style.
      */
     public Map<String, LegendInfo> getLegendsInfo() {
-        return Collections.EMPTY_MAP;
-    }
-
-    /**
-     * Information container for a style legend.
-     */
-    public static class LegendInfo {
-
-        public String id;
-        public int width;
-        public int height;
-        public String format;
-        public String legendUrl;
-    }
-
-    /**
-     * Helper constructor for legend info;
-     */
-    public static LegendInfo createLegendInfo() {
-        return new LegendInfo();
+        return Collections.emptyMap();
     }
 
     /**

--- a/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSLayer.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/layer/wms/WMSLayer.java
@@ -33,6 +33,8 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geowebcache.GeoWebCacheException;
+import org.geowebcache.config.legends.LegendInfo;
+import org.geowebcache.config.legends.LegendsRawInfo;
 import org.geowebcache.config.XMLGridSubset;
 import org.geowebcache.conveyor.Conveyor.CacheResult;
 import org.geowebcache.conveyor.ConveyorTile;
@@ -117,6 +119,8 @@ public class WMSLayer extends AbstractTileLayer implements ProxyLayer {
     protected transient String sphericalMercatorOverride;
 
     private transient LockProvider lockProvider;
+
+    private LegendsRawInfo legends;
 
     WMSLayer() {
         //default constructor for XStream
@@ -853,5 +857,20 @@ public class WMSLayer extends AbstractTileLayer implements ProxyLayer {
             IOUtils.closeQuietly(is);
         }
         
+    }
+
+    public LegendsRawInfo getLegends() {
+        return legends;
+    }
+
+    public void setLegends(LegendsRawInfo legends) {
+        this.legends = legends;
+    }
+
+    @Override
+    public Map<String, LegendInfo> getLegendsInfo() {
+        String layerName = wmsLayers == null ? getName() : wmsLayers;
+        return legends == null ? super.getLegendsInfo() :
+                legends.getLegendsInfo(layerName, wmsUrl != null && wmsUrl.length > 0 ? wmsUrl[0] : null);
     }
 }

--- a/geowebcache/core/src/main/resources/geowebcache.xml
+++ b/geowebcache/core/src/main/resources/geowebcache.xml
@@ -152,6 +152,14 @@
       <wmsUrl>
         <string>http://demo.opengeo.org/geoserver/topp/wms</string>
       </wmsUrl>
+      <legends defaultWidth="81" defaultHeight="80" defaultFormat="image/png">
+        <legend style="population"/>
+        <legend style="pophatch"/>
+        <legend style="polygon">
+          <width>20</width>
+          <height>20</height>
+        </legend>
+      </legends>
     </wmsLayer>
 
     <wmsLayer>
@@ -166,6 +174,9 @@
         <string>http://demo.opengeo.org/geoserver/wms</string>
       </wmsUrl>
       <wmsLayers>nurc:Img_Sample</wmsLayers>
+      <legends defaultWidth="20" defaultHeight="20" defaultFormat="image/png">
+        <legend style=""/>
+      </legends>
     </wmsLayer>
 
     <wmsLayer>
@@ -206,6 +217,18 @@
       <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
       <transparent>false</transparent>
       <bgColor>0x0066FF</bgColor>
+      <legends defaultWidth="81" defaultHeight="80" defaultFormat="image/png">
+        <legend style="population"/>
+        <legend style="pophatch"/>
+        <legend style="polygon">
+          <width>20</width>
+          <height>20</height>
+        </legend>
+        <legend style="raster">
+          <width>20</width>
+          <height>20</height>
+        </legend>
+      </legends>
     </wmsLayer>
   </layers>
 

--- a/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
+++ b/geowebcache/core/src/main/resources/org/geowebcache/config/geowebcache.xsd
@@ -124,13 +124,13 @@
             </xs:documentation>
           </xs:annotation>
         </xs:element>
-        
+
         <xs:element name="blobStores" minOccurs="0" maxOccurs="1">
           <xs:annotation>
             <xs:documentation xml:lang="en">
               The list of  blob stores. BlobStores allow to define a storage mechanism and format, such as the legacy file system
               based storage, an Amazon S3 instance with a TMS-like key structure, etc; independently of where the tiles come from
-              in the TileLayer configuration. 
+              in the TileLayer configuration.
             </xs:documentation>
           </xs:annotation>
           <xs:complexType>
@@ -139,7 +139,7 @@
             </xs:sequence>
           </xs:complexType>
         </xs:element>
-        
+
         <xs:element name="gridSets" minOccurs="0">
           <xs:annotation>
             <xs:documentation xml:lang="en">
@@ -166,11 +166,11 @@
               <xs:element ref="gwc:arcgisLayer" />
             </xs:choice>
           </xs:complexType>
-        </xs:element>	        
+        </xs:element>
       	<xs:element name="fullWMS" type="xs:boolean" minOccurs="0">
            <xs:annotation>
              <xs:documentation xml:lang="en">
-		Parameter used for configuring full WMS requests for GeoWebCache. Setting this parameter to true enables full WMS requests. 
+		Parameter used for configuring full WMS requests for GeoWebCache. Setting this parameter to true enables full WMS requests.
              </xs:documentation>
            </xs:annotation>
         </xs:element>
@@ -213,17 +213,17 @@
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
-  
+
   <xs:element name="blobstore" type="gwc:AbstractBlobStore">
   </xs:element>
-  
+
   <xs:element name="FileBlobStore" substitutionGroup="gwc:blobstore">
     <xs:complexType>
       <xs:complexContent>
         <xs:extension base="gwc:AbstractBlobStore">
           <xs:sequence>
             <xs:element name="baseDirectory" type="xs:string" minOccurs="1" maxOccurs="1">
-              
+
             </xs:element>
             <xs:element name="fileSystemBlockSize" type="xs:positiveInteger" minOccurs="0" maxOccurs="1" nillable="true">
             </xs:element>
@@ -232,7 +232,7 @@
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
-  
+
   <xs:element name="S3BlobStore" substitutionGroup="gwc:blobstore">
     <xs:complexType>
       <xs:complexContent>
@@ -276,14 +276,14 @@
               <xs:annotation>
                 <xs:documentation xml:lang="en">
                 The optional Windows domain name for configuring an NTLM proxy.
-                If you aren't using a Windows NTLM proxy, you do not need to set this field. 
+                If you aren't using a Windows NTLM proxy, you do not need to set this field.
                 </xs:documentation>
               </xs:annotation>
             </xs:element>
             <xs:element name="proxyWorkstation" type="xs:string" minOccurs="0" nillable="true">
               <xs:annotation>
                 <xs:documentation xml:lang="en">
-                The optional Windows workstation name for configuring NTLM proxy support. 
+                The optional Windows workstation name for configuring NTLM proxy support.
                 If you aren't using a Windows NTLM proxy, you do not need to set this field.
                 </xs:documentation>
               </xs:annotation>
@@ -373,7 +373,7 @@
           <xs:documentation xml:lang="en">
             List of formats to be supported for GetFeatureInfo. These must be known to
             GeoWebCache. Legal values are
-            text/plain, text/html, application/vnd.ogc.gml and application/json 
+            text/plain, text/html, application/vnd.ogc.gml and application/json
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -533,7 +533,7 @@
         <xs:annotation>
           <xs:documentation xml:lang="en">
             The QUERY_LAYERS value sent to the WMS backend server. This should
-            refer to one or more (comma separated) queryable layers. If omitted, 
+            refer to one or more (comma separated) queryable layers. If omitted,
             the wmsLayers will be used.
           </xs:documentation>
         </xs:annotation>
@@ -563,7 +563,7 @@
                 A list of URLs to backend servers than can render tiles for this
                 layer. They are used in a
                 round robin fashion for load balancing and automatic failover.
-    
+
                 The only time you can
                 ommit this element is if you expect the layer to be merged
                 with that from another source.
@@ -714,7 +714,14 @@
                 An indication of how many concurrent threads can simultaneously request tiles from this layer with
                 minimal thread contention. If not set defaults to 32. This property is deprecated and scheduled to
                 be removed in 1.4.0.
-              </xs:documentation> 
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element type="gwc:legendsType" name="legends" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation xml:lang="en">
+                Defines legends information for this layer styles.
+              </xs:documentation>
             </xs:annotation>
           </xs:element>
         </xs:sequence>
@@ -777,7 +784,7 @@
       <xs:element name="advertised" type="xs:boolean" minOccurs="0">
         <xs:annotation>
           <xs:documentation xml:lang="en">
-            Whether the layer is included in capabilities documents. Defaults 
+            Whether the layer is included in capabilities documents. Defaults
 	    to true.  When false the layer will not be included in capabilities
 	    documents but will otherwise work normally.
           </xs:documentation>
@@ -786,7 +793,7 @@
       <xs:element name="transientLayer" type="xs:boolean" minOccurs="0">
         <xs:annotation>
           <xs:documentation xml:lang="en">
-            Is the layer transient.  Defaults to false.  A transient layer's 
+            Is the layer transient.  Defaults to false.  A transient layer's
 	    configuration will not be persisted over restart/reload.  This does
 	    not affect the persistence of tiles.
           </xs:documentation>
@@ -2055,5 +2062,83 @@
         </xs:annotation>
       </xs:element>
     </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="legendType" mixed="true">
+    <xs:sequence>
+      <xs:element type="xs:integer" name="width" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            Legend width.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element type="xs:integer" name="height" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            Legend height.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element type="xs:string" name="format" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            Legend format.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element type="xs:string" name="url" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            URL that should be used to produce the legend get URL.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element type="xs:string" name="completeUrl" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            Complete URL that should be used as is.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute type="xs:string" name="style" use="optional">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">
+          The style that corresponds to this legend.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="legendsType">
+    <xs:sequence>
+      <xs:element type="gwc:legendType" name="legend" maxOccurs="unbounded" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            A style legend definition.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute type="xs:string" name="defaultWidth">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">
+          Default width that should be used if no legend width is defined.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute type="xs:string" name="defaultHeight">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">
+          Default height that should be used if no legend height is defined.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute type="xs:string" name="defaultFormat">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">
+          Default format that should be used if no legend format is defined.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
   </xs:complexType>
 </xs:schema>

--- a/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/XMLConfigurationTest.java
@@ -1,5 +1,6 @@
 package org.geowebcache.config;
 
+import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.junit.Assert.*;
@@ -18,6 +19,8 @@ import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.geowebcache.config.legends.LegendRawInfo;
+import org.geowebcache.config.legends.LegendsRawInfo;
 import org.geowebcache.filter.parameters.ParameterFilter;
 import org.geowebcache.filter.parameters.StringParameterFilter;
 import org.geowebcache.grid.BoundingBox;
@@ -29,6 +32,8 @@ import org.geowebcache.grid.GridSubsetFactory;
 import org.geowebcache.grid.SRS;
 import org.geowebcache.layer.TileLayer;
 import org.geowebcache.layer.wms.WMSLayer;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -173,8 +178,32 @@ public class XMLConfigurationTest {
         WMSLayer layer = new WMSLayer(layerName, wmsURL, wmsStyles, wmsLayers, mimeFormats,
                 subSets, parameterFilters, metaWidthHeight, vendorParams, queryable, wmsQueryLayers);
 
-        config.addLayer(layer);
+        // create legends information
+        LegendsRawInfo legendsRawInfo = new LegendsRawInfo();
+        legendsRawInfo.setDefaultWidth(50);
+        legendsRawInfo.setDefaultHeight(100);
+        legendsRawInfo.setDefaultFormat("image/png");
+        // legend with all values and custom url
+        LegendRawInfo legendRawInfoA = new LegendRawInfo();
+        legendRawInfoA.setStyle("polygon");
+        legendRawInfoA.setWidth(75);
+        legendRawInfoA.setHeight(125);
+        legendRawInfoA.setFormat("image/jpeg");
+        legendRawInfoA.setUrl("http://url");
+        // legend with a complete url
+        LegendRawInfo legendRawInfoB = new LegendRawInfo();
+        legendRawInfoB.setStyle("point");
+        legendRawInfoB.setCompleteUrl("http://url");
+        // default style legend
+        LegendRawInfo legendRawInfoC = new LegendRawInfo();
+        legendRawInfoC.setStyle("");
+        // tie the legend information together
+        legendsRawInfo.addLegendRawInfo(legendRawInfoA);
+        legendsRawInfo.addLegendRawInfo(legendRawInfoB);
+        legendsRawInfo.addLegendRawInfo(legendRawInfoC);
+        layer.setLegends(legendsRawInfo);
 
+        config.addLayer(layer);
         config.save();
 
         try {
@@ -201,6 +230,14 @@ public class XMLConfigurationTest {
             assertNotNull(actual);
             assertEquals(new XMLGridSubset(expected), new XMLGridSubset(actual));
         }
+
+        // check legends info
+        assertThat(l.getLegends(), notNullValue());
+        assertThat(l.getLegends().getDefaultWidth(), is(50));
+        assertThat(l.getLegends().getDefaultHeight(), is(100));
+        assertThat(l.getLegends().getDefaultFormat(), is("image/png"));
+        assertThat(l.getLegends().getLegendsRawInfo().size(), is(3));
+        assertThat(l.getLegends().getLegendsRawInfo(), containsInAnyOrder(legendRawInfoA, legendRawInfoB, legendRawInfoC));
     }
 
     @Test

--- a/geowebcache/core/src/test/java/org/geowebcache/config/legends/LegendInfoBuilderTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/legends/LegendInfoBuilderTest.java
@@ -1,0 +1,127 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Nuno Oliveira, GeoSolutions S.A.S., Copyright 2016
+ */
+package org.geowebcache.config.legends;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+/**
+ * Test styles legends info different combinations.
+ */
+public class LegendInfoBuilderTest {
+
+    @Test
+    public void testWithOnlyDefaults() {
+        LegendInfo legendInfo = new LegendInfoBuilder()
+                .withLayerName("layer1")
+                .withLayerUrl("http://localhost:8080/geoserver")
+                .withDefaultWidth(50)
+                .withDefaultHeight(100)
+                .withDefaultFormat("image/png")
+                .build();
+        assertThat(legendInfo.getWidth(), is(50));
+        assertThat(legendInfo.getHeight(), is(100));
+        assertThat(legendInfo.getFormat(), is("image/png"));
+        assertThat(legendInfo.getStyleName(), is(""));
+        assertThat(legendInfo.getLegendUrl(), is("http://localhost:8080/geoserver?" +
+                "service=WMS&request=GetLegendGraphic&format=image/png&width=50&height=100&layer=layer1&style="));
+    }
+
+    @Test
+    public void testWithValues() {
+        LegendInfo legendInfo = new LegendInfoBuilder()
+                .withLayerName("layer1")
+                .withLayerUrl("http://localhost:8080/geoserver")
+                .withDefaultWidth(50)
+                .withDefaultHeight(100)
+                .withDefaultFormat("image/png")
+                .withStyleName("style1")
+                .withWidth(150)
+                .withHeight(200)
+                .withFormat("image/gif")
+                .build();
+        assertThat(legendInfo.getWidth(), is(150));
+        assertThat(legendInfo.getHeight(), is(200));
+        assertThat(legendInfo.getFormat(), is("image/gif"));
+        assertThat(legendInfo.getStyleName(), is("style1"));
+        assertThat(legendInfo.getLegendUrl(), is("http://localhost:8080/geoserver?" +
+                "service=WMS&request=GetLegendGraphic&format=image/gif&width=150&height=200&layer=layer1&style=style1"));
+    }
+
+    @Test
+    public void testWithUrl() {
+        LegendInfo legendInfo = new LegendInfoBuilder()
+                .withLayerName("layer1")
+                .withLayerUrl("http://localhost:8080/geoserver")
+                .withDefaultWidth(50)
+                .withDefaultHeight(100)
+                .withDefaultFormat("image/png")
+                .withStyleName("style1")
+                .withWidth(150)
+                .withHeight(200)
+                .withFormat("image/gif")
+                .withUrl("http://localhost:9090/image.gif?")
+                .build();
+        assertThat(legendInfo.getWidth(), is(150));
+        assertThat(legendInfo.getHeight(), is(200));
+        assertThat(legendInfo.getFormat(), is("image/gif"));
+        assertThat(legendInfo.getStyleName(), is("style1"));
+        assertThat(legendInfo.getLegendUrl(), is("http://localhost:9090/image.gif?" +
+                "service=WMS&request=GetLegendGraphic&format=image/gif&width=150&height=200&layer=layer1&style=style1"));
+    }
+
+    @Test
+    public void testWithCompleteUrl() {
+        LegendInfo legendInfo = new LegendInfoBuilder()
+                .withLayerName("layer1")
+                .withLayerUrl("http://localhost:8080/geoserver")
+                .withDefaultWidth(50)
+                .withDefaultHeight(100)
+                .withDefaultFormat("image/png")
+                .withStyleName("style1")
+                .withWidth(150)
+                .withHeight(200)
+                .withFormat("image/gif")
+                .withCompleteUrl("http://my.server.com/image.gif")
+                .build();
+        assertThat(legendInfo.getWidth(), is(150));
+        assertThat(legendInfo.getHeight(), is(200));
+        assertThat(legendInfo.getFormat(), is("image/gif"));
+        assertThat(legendInfo.getStyleName(), is("style1"));
+        assertThat(legendInfo.getLegendUrl(), is("http://my.server.com/image.gif"));
+    }
+
+    @Test
+    public void testWithValuesNoDefaults() {
+        LegendInfo legendInfo = new LegendInfoBuilder()
+                .withLayerName("layer1")
+                .withLayerUrl("http://localhost:8080/geoserver")
+                .withStyleName("style1")
+                .withWidth(150)
+                .withHeight(200)
+                .withFormat("image/gif")
+                .build();
+        assertThat(legendInfo.getWidth(), is(150));
+        assertThat(legendInfo.getHeight(), is(200));
+        assertThat(legendInfo.getFormat(), is("image/gif"));
+        assertThat(legendInfo.getStyleName(), is("style1"));
+        assertThat(legendInfo.getLegendUrl(), is("http://localhost:8080/geoserver?" +
+                "service=WMS&request=GetLegendGraphic&format=image/gif&width=150&height=200&layer=layer1&style=style1"));
+    }
+}

--- a/geowebcache/wms/src/main/java/org/geowebcache/config/GetCapabilitiesConfiguration.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/config/GetCapabilitiesConfiguration.java
@@ -18,7 +18,6 @@
 package org.geowebcache.config;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,6 +30,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -43,9 +45,13 @@ import org.geotools.data.wms.xml.Dimension;
 import org.geotools.data.wms.xml.Extent;
 import org.geotools.ows.ServiceException;
 import org.geowebcache.GeoWebCacheException;
+import org.geowebcache.config.legends.LegendInfo;
+import org.geowebcache.config.legends.LegendRawInfo;
+import org.geowebcache.config.legends.LegendsRawInfo;
 import org.geowebcache.config.meta.ServiceInformation;
 import org.geowebcache.filter.parameters.NaiveWMSDimensionFilter;
 import org.geowebcache.filter.parameters.ParameterFilter;
+import org.geowebcache.filter.parameters.StringParameterFilter;
 import org.geowebcache.grid.BoundingBox;
 import org.geowebcache.grid.GridSet;
 import org.geowebcache.grid.GridSetBroker;
@@ -60,8 +66,14 @@ import org.geowebcache.layer.wms.WMSHttpHelper;
 import org.geowebcache.layer.wms.WMSLayer;
 
 public class GetCapabilitiesConfiguration implements Configuration {
+
     private static Log log = LogFactory
             .getLog(org.geowebcache.config.GetCapabilitiesConfiguration.class);
+
+    // regex patterns used to parse legends urls parameters
+    private static final Pattern LEGEND_WIDTH_PATTERN = Pattern.compile(".*width=(\\d+).*", Pattern.CASE_INSENSITIVE);
+    private static final Pattern LEGEND_HEIGHT_PATTERN = Pattern.compile(".*height=(\\d+).*", Pattern.CASE_INSENSITIVE);
+    private static final Pattern LEGEND_FORMAT_PATTERN = Pattern.compile(".*format=([^&]+).*", Pattern.CASE_INSENSITIVE);
 
     private GridSetBroker gridSetBroker;
 
@@ -210,6 +222,8 @@ public class GetCapabilitiesConfiguration implements Configuration {
             boolean queryable = layer.isQueryable();
 
             if (name != null) {
+
+                LinkedList<ParameterFilter> paramFilters = new LinkedList<ParameterFilter>();
                 List<StyleImpl> styles = layer.getStyles();
 
                 StringBuffer buf = new StringBuffer();
@@ -224,6 +238,11 @@ public class GetCapabilitiesConfiguration implements Configuration {
                         hasOne = true;
                     }
                     stylesStr = buf.toString();
+                    // set styles parameters
+                    StringParameterFilter stylesParameterFilter = new StringParameterFilter();
+                    stylesParameterFilter.setKey("STYLES");
+                    stylesParameterFilter.setValues(styles.stream().map(StyleImpl::getName).collect(Collectors.toList()));
+                    paramFilters.add(stylesParameterFilter);
                 }
 
                 double minX = layer.getLatLonBoundingBox().getMinX();
@@ -242,7 +261,6 @@ public class GetCapabilitiesConfiguration implements Configuration {
 
                 String[] wmsUrls = { wmsUrl };
 
-                LinkedList<ParameterFilter> paramFilters = new LinkedList<ParameterFilter>();
                 for (Dimension dimension : layer.getDimensions().values()) {
                     Extent dimExtent = layer.getExtent(dimension.getName());
                     paramFilters.add(new NaiveWMSDimensionFilter(dimension, dimExtent));
@@ -283,12 +301,65 @@ public class GetCapabilitiesConfiguration implements Configuration {
                         wmsLayer.setMetadataURLs(convertedMetadataURLs);
                     }
 
+                    // add styles legend information
+                    wmsLayer.setLegends(extractLegendsInfo(styles));
+
                     layers.add(wmsLayer);
                 }
             }
         }
 
         return layers;
+    }
+
+    /**
+     * Helper method that extracts from a legend url the width, height and format parameters.
+     */
+    private LegendsRawInfo extractLegendsInfo(List<StyleImpl> styles) {
+        LegendsRawInfo legendsRawInfo = new LegendsRawInfo();
+        // setting some acceptable default values
+        legendsRawInfo.setDefaultWidth(20);
+        legendsRawInfo.setDefaultHeight(20);
+        legendsRawInfo.setDefaultFormat("image/png");
+        for (StyleImpl style : styles) {
+            // extracting legend information from each style
+            LegendRawInfo legendRawInfo = new LegendRawInfo();
+            legendRawInfo.setStyle(style.getName());
+            List legendUrls = style.getLegendURLs();
+            if (legendUrls != null && !legendUrls.isEmpty()) {
+                String legendUrl = (String) legendUrls.get(0);
+                // let's see if we can extract width, height and format from the style legend url
+                legendRawInfo.setWidth(extractIntegerParameter(legendUrl, LEGEND_WIDTH_PATTERN));
+                legendRawInfo.setHeight(extractIntegerParameter(legendUrl, LEGEND_HEIGHT_PATTERN));
+                legendRawInfo.setFormat(extractParameter(legendUrl, LEGEND_FORMAT_PATTERN));
+                // setting the complete legend url
+                legendRawInfo.setCompleteUrl(legendUrl);
+            }
+            legendsRawInfo.addLegendRawInfo(legendRawInfo);
+        }
+        return legendsRawInfo;
+    }
+
+    /**
+     * Helper method that simply extracts from the provided url a certain parameter.
+     */
+    private String extractParameter(String url, Pattern pattern) {
+        Matcher matcher = pattern.matcher(url);
+        if (matcher.matches()) {
+            return matcher.group(1);
+        }
+        return null;
+    }
+
+    /**
+     * Helper method that simply extracts from the provided url a certain integer parameter.
+     */
+    private Integer extractIntegerParameter(String url, Pattern pattern) {
+        String value = extractParameter(url, pattern);
+        if (value == null) {
+            return null;
+        }
+        return Integer.valueOf(value);
     }
 
     private WMSLayer getLayer(String name, String[] wmsurl, BoundingBox bounds4326,

--- a/geowebcache/wms/src/test/java/org/geowebcache/config/GetCapabilitiesConfigurationTest.java
+++ b/geowebcache/wms/src/test/java/org/geowebcache/config/GetCapabilitiesConfigurationTest.java
@@ -1,21 +1,21 @@
 package org.geowebcache.config;
 
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.*;
 import static org.easymock.classextension.EasyMock.*;
 
 import java.net.URL;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
 import org.easymock.Capture;
-import org.geotools.data.ows.CRSEnvelope;
-import org.geotools.data.ows.Layer;
-import org.geotools.data.ows.OperationType;
-import org.geotools.data.ows.WMSCapabilities;
-import org.geotools.data.ows.WMSRequest;
+import org.geotools.data.ows.*;
 import org.geotools.data.wms.WebMapServer;
 import org.geowebcache.grid.GridSetBroker;
 import org.geowebcache.layer.TileLayer;
+import org.geowebcache.layer.wms.WMSLayer;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,10 +59,18 @@ public class GetCapabilitiesConfigurationTest {
         expect(cap.getVersion()).andStubReturn("1.1.1");
         
         List<Layer> layers = new LinkedList<Layer>();
-        
+
+        // create a test layer
         Layer l = new Layer();
         l.setName("Foo");
         l.setLatLonBoundingBox(new CRSEnvelope());
+        // create a style for this layer
+        StyleImpl style = new StyleImpl();
+        style.setName("style1");
+        style.setLegendURLs(Collections.singletonList("http://localhost:8080/geoserver/topp/wms?" +
+                "service=WMS&request=GetLegendGraphic&format=image/gif&width=50&height=100&layer=topp:states&style=polygon"));
+        l.setStyles(Collections.singletonList(style));
+        // add the test layer
         layers.add(l);
         
         globalConfig.setDefaultValues(capture(layerCapture)); expectLastCall().times(layers.size());
@@ -76,9 +84,24 @@ public class GetCapabilitiesConfigurationTest {
         config.initialize(broker);
         
         // Check that the XMLConfiguration's setDefaultValues method has been called on each of the layers returened.
-        assertThat(Sets.newHashSet(config.getLayers()), Matchers.is(Sets.newHashSet(layerCapture.getValues())));
+        assertThat(Sets.newHashSet(config.getLayers()), is(Sets.newHashSet(layerCapture.getValues())));
         
         verify(server, cap, req, gcOpType, globalConfig);
+
+        // check legends information
+        WMSLayer wmsLayer = (WMSLayer) config.getTileLayer("Foo");
+        assertThat(wmsLayer, notNullValue());
+        assertThat(wmsLayer.getLegends(), notNullValue());
+        // check legends default for the test layer
+        assertThat(wmsLayer.getLegends().getDefaultWidth(), is(20));
+        assertThat(wmsLayer.getLegends().getDefaultHeight(), is(20));
+        assertThat(wmsLayer.getLegends().getDefaultFormat(), is("image/png"));
+        // check style legend information
+        assertThat(wmsLayer.getLegends().getLegendsRawInfo(), notNullValue());
+        assertThat(wmsLayer.getLegends().getLegendsRawInfo().size(), is(1));
+        assertThat(wmsLayer.getLegends().getLegendsRawInfo().get(0).getWidth(), is(50));
+        assertThat(wmsLayer.getLegends().getLegendsRawInfo().get(0).getHeight(), is(100));
+        assertThat(wmsLayer.getLegends().getLegendsRawInfo().get(0).getFormat(), is("image/gif"));
     }
     
 }

--- a/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
+++ b/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSGetCapabilities.java
@@ -32,6 +32,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.geowebcache.config.legends.LegendInfo;
 import org.geowebcache.config.meta.ServiceContact;
 import org.geowebcache.config.meta.ServiceInformation;
 import org.geowebcache.config.meta.ServiceProvider;
@@ -481,12 +482,12 @@ public class WMTSGetCapabilities {
      
      private void layerStyles(XMLBuilder xml, TileLayer layer, List<ParameterFilter> filters) throws IOException {
          String defStyle = layer.getStyles();
-         Map<String, TileLayer.LegendInfo> legendsInfo = layer.getLegendsInfo();
+         Map<String, LegendInfo> legendsInfo = layer.getLegendsInfo();
          if(filters == null) {
              xml.indentElement("Style");
              xml.attribute("isDefault", "true");
              if(defStyle == null) {
-                 xml.simpleElement("ows:Identifier", "", true);
+                 xml.simpleElement("ows:Identifier", "", true); 
              } else {
                  xml.simpleElement("ows:Identifier", TileLayer.encodeDimensionValue(defStyle), true);
              }
@@ -538,18 +539,18 @@ public class WMTSGetCapabilities {
          }
      }
 
-    private void encodeStyleLegenGraphic(XMLBuilder xml, TileLayer.LegendInfo legendInfo) throws IOException {
+    private void encodeStyleLegenGraphic(XMLBuilder xml, LegendInfo legendInfo) throws IOException {
         if (legendInfo == null) {
             return;
         }
         xml.indentElement("LegendURL");
-        xml.attribute("width", String.valueOf(legendInfo.width));
-        xml.attribute("height", String.valueOf(legendInfo.height));
-        if (legendInfo.format != null) {
-            xml.attribute("format", legendInfo.format);
+        xml.attribute("width", String.valueOf(legendInfo.getWidth()));
+        xml.attribute("height", String.valueOf(legendInfo.getHeight()));
+        if (legendInfo.getFormat() != null) {
+            xml.attribute("format", legendInfo.getFormat());
         }
-        if(legendInfo.legendUrl != null) {
-            xml.attribute("xlink:href", legendInfo.legendUrl);
+        if(legendInfo.getLegendUrl() != null) {
+            xml.attribute("xlink:href", legendInfo.getLegendUrl());
         }
         xml.endElement("LegendURL");
     }

--- a/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSServiceTest.java
+++ b/geowebcache/wmts/src/test/java/org/geowebcache/service/wmts/WMTSServiceTest.java
@@ -33,6 +33,8 @@ import org.custommonkey.xmlunit.XpathEngine;
 import org.custommonkey.xmlunit.Validator;
 import org.geowebcache.GeoWebCacheDispatcher;
 import org.geowebcache.config.XMLGridSubset;
+import org.geowebcache.config.legends.LegendInfo;
+import org.geowebcache.config.legends.LegendInfoBuilder;
 import org.geowebcache.config.meta.ServiceContact;
 import org.geowebcache.config.meta.ServiceInformation;
 import org.geowebcache.config.meta.ServiceProvider;
@@ -172,12 +174,13 @@ public class WMTSServiceTest extends TestCase {
             when(tileLayer.getParameterFilters()).thenReturn(Collections.singletonList(styles));
 
             // add legend info for style-b
-            TileLayer.LegendInfo legendInfo = TileLayer.createLegendInfo();
-            legendInfo.id = "styla-a-legend";
-            legendInfo.width = 125;
-            legendInfo.height = 130;
-            legendInfo.format = "image/png";
-            legendInfo.legendUrl = "https://some-url?some-parameter=value&another-parameter=value";
+            LegendInfo legendInfo = new LegendInfoBuilder()
+                    .withStyleName("styla-a-legend")
+                    .withWidth(125)
+                    .withHeight(130)
+                    .withFormat("image/png")
+                    .withCompleteUrl("https://some-url?some-parameter=value&another-parameter=value")
+                    .build();
             when(tileLayer.getLegendsInfo()).thenReturn(Collections.singletonMap("style-b", legendInfo));
 
             // add some layer metadata


### PR DESCRIPTION
Allows standalone GWC instances to provided styles legends information. Tests were updated and new tests were added.  The documentation was also updated.